### PR TITLE
Fix HTML encoding issues with special characters in passwords

### DIFF
--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -73,6 +73,8 @@ class AuthController
         $username = $data['username'] ?? '';
         $password = $data['password'] ?? '';
         $authMethod = $data['auth_method'] ?? 'ldap'; // Default to LDAP for backward compatibility
+
+        $password = html_entity_decode($password, ENT_QUOTES | ENT_HTML5, 'UTF-8');
         
         if (empty($username) || empty($password)) {
             return $response


### PR DESCRIPTION
When a user's password contains &, <, >, or ", the password arrives with these characters HTML-encoded.

This change decodes HTML entities for the submitted password in AuthController::processLogin() to prevent login failures.