### PR TITLE
fix(site): use canonical www host for sitemap URLs

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -3,13 +3,13 @@ import sitemap from '@astrojs/sitemap';
 import tailwindcss from '@tailwindcss/vite';
 
 export default defineConfig({
-  site: 'https://jeffcaldwell.ca',
+  site: 'https://www.jeffcaldwell.ca',
   base: '/support-portal',
   trailingSlash: 'ignore',
   integrations: [
     sitemap({
       serialize(item) {
-        const root = 'https://jeffcaldwell.ca/support-portal/';
+        const root = 'https://www.jeffcaldwell.ca/support-portal/';
         if (item.url !== root) {
           item.url = item.url.replace(/\/$/, '');
         }


### PR DESCRIPTION
## What

Point the Astro `site` config (and the `serialize()` root sentinel that depends on it) at `https://www.jeffcaldwell.ca` instead of the apex `https://jeffcaldwell.ca`.

## Why

The published Pages site lives at the canonical `www.jeffcaldwell.ca` host (the apex 301-redirects to www). With `site` set to the apex, `@astrojs/sitemap` emitted `https://jeffcaldwell.ca/support-portal/...` URLs in `sitemap-0.xml` — every entry pointing at a redirect rather than the canonical URL.

This matters now because the main site (`jeffcaldwellca.github.io`) added a root sitemap **index** that references this subsite's `sitemap-0.xml`. Emitting canonical www URLs keeps the whole index consistent and avoids feeding crawlers redirecting URLs.

## Note

The `root` sentinel in `serialize()` is updated in lockstep — it's compared against `item.url` to keep the homepage's trailing slash while stripping it from all other pages. Leaving it on the apex value would have broken that comparison and stripped the homepage slash too.

## Verifying

`node --check` passes. After this deploys, `https://www.jeffcaldwell.ca/support-portal/sitemap-0.xml` should list `https://www.jeffcaldwell.ca/...` URLs.