### PR TITLE
chore: refine tagline / drop redundant name suffix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Scout Portal for FreeScout
+# Scout Portal
 
 A web-based support portal that integrates with FreeScout (support ticketing system), providing a user-friendly form interface for submitting and tracking support requests.
 

--- a/site/public/llms.txt
+++ b/site/public/llms.txt
@@ -1,4 +1,4 @@
-# Scout Portal for FreeScout
+# Scout Portal
 
 > A free, self-hosted, open-source end-user portal for FreeScout. It gives users a clean,
 > form-based interface to submit support tickets, attach files, and track status — with LDAP

--- a/site/public/site.webmanifest
+++ b/site/public/site.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "Scout Portal for FreeScout",
+  "name": "Scout Portal",
   "short_name": "Scout Portal",
   "icons": [
     { "src": "/scout-portal/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },

--- a/site/src/assets/og-image.svg
+++ b/site/src/assets/og-image.svg
@@ -2,8 +2,8 @@
   <rect width="1200" height="630" fill="#ffffff"/>
   <rect width="1200" height="12" fill="#2563eb"/>
   <text x="80" y="250" font-family="sans-serif" font-size="76" font-weight="800" fill="#111212">Scout Portal</text>
-  <text x="80" y="340" font-family="sans-serif" font-size="44" font-weight="600" fill="#2563eb">for FreeScout</text>
-  <text x="80" y="430" font-family="sans-serif" font-size="32" fill="#475569">A friendly, self-hosted customer portal.</text>
+  <text x="80" y="340" font-family="sans-serif" font-size="44" font-weight="600" fill="#2563eb">for your FreeScout helpdesk</text>
+  <text x="80" y="430" font-family="sans-serif" font-size="32" fill="#475569">A friendly, self-hosted front end for your users.</text>
   <text x="80" y="478" font-family="sans-serif" font-size="32" fill="#475569">Dynamic forms · LDAP/local auth · file uploads.</text>
   <text x="80" y="575" font-family="sans-serif" font-size="26" fill="#94a3b8">Free &amp; open-source · GPL v3 · github.com/jeffcaldwellca/scout-portal</text>
 </svg>

--- a/site/src/content/docs/deployment.md
+++ b/site/src/content/docs/deployment.md
@@ -1,6 +1,6 @@
 ---
 title: Docker & Deployment
-description: Deploy Scout Portal for FreeScout with Docker, Apache, or Nginx, and schedule the maintenance cleanup job.
+description: Deploy Scout Portal with Docker, Apache, or Nginx, and schedule the maintenance cleanup job.
 order: 5
 howTo:
   name: Deploy Scout Portal with Docker

--- a/site/src/content/docs/installation.md
+++ b/site/src/content/docs/installation.md
@@ -1,9 +1,9 @@
 ---
 title: Installation
-description: How to install Scout Portal for FreeScout — prerequisites, Composer, environment config, web server setup, and connecting the FreeScout API.
+description: How to install Scout Portal — prerequisites, Composer, environment config, web server setup, and connecting the FreeScout API.
 order: 2
 howTo:
-  name: Install Scout Portal for FreeScout
+  name: Install Scout Portal
   description: Install and configure the self-hosted FreeScout customer portal.
   steps:
     - Clone the repository from GitHub.

--- a/site/src/data/faq.ts
+++ b/site/src/data/faq.ts
@@ -2,7 +2,7 @@ export interface FaqItem { q: string; a: string; }
 
 export const FAQ_ITEMS: FaqItem[] = [
   {
-    q: 'What is Scout Portal for FreeScout?',
+    q: 'What is Scout Portal?',
     a: 'Scout Portal is a free, self-hosted, open-source web app that gives your end users a friendly form-based interface to submit support tickets to FreeScout, attach files, and track ticket status — without giving them access to the FreeScout agent UI.',
   },
   {

--- a/site/src/data/seo.ts
+++ b/site/src/data/seo.ts
@@ -1,9 +1,9 @@
 export const SITE = {
   origin: 'https://jeffcaldwell.ca',
   base: '/scout-portal',
-  name: 'Scout Portal for FreeScout',
+  name: 'Scout Portal',
   shortName: 'Scout Portal',
-  tagline: 'A friendly self-hosted customer portal for FreeScout',
+  tagline: 'A friendly, self-hosted front end for your FreeScout helpdesk',
   description:
     'Scout Portal is a free, self-hosted, open-source end-user portal for FreeScout. It gives your users a clean form-based interface to submit support tickets, attach files, and track status — with LDAP or local authentication.',
   repo: 'https://github.com/jeffcaldwellca/scout-portal',

--- a/site/src/pages/faq.astro
+++ b/site/src/pages/faq.astro
@@ -11,7 +11,7 @@ const jsonLd = [
 ---
 <BaseLayout
   title="FAQ"
-  description="Answers to common questions about Scout Portal for FreeScout: what it is, whether it's free, requirements, LDAP support, Docker, and security."
+  description="Answers to common questions about Scout Portal: what it is, whether it's free, requirements, LDAP support, Docker, and security."
   path="/faq"
   jsonLd={jsonLd}
 >


### PR DESCRIPTION
Follow-up to the scout-portal rename. Makes the branding read better:

- Formal name `Scout Portal for FreeScout` → `Scout Portal` (FreeScout context stays in descriptions/body)
- Tagline → **A friendly, self-hosted front end for your FreeScout helpdesk** (no more "portal … portal" repetition in the page title)
- og-image subtitle → `for your FreeScout helpdesk` + refreshed description line

Verified: site unit tests 11/11, `npm run verify` (build + SEO check) passes, og-image regenerated.