### PR TITLE
chore: exclude marketing site from Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -38,3 +38,11 @@ tmp/
 # Testing
 tests/
 .phpunit.cache
+
+# Marketing site — deployed separately to GitHub Pages, not part of the app image
+site/
+screenshot.png
+
+# Node dependencies (never used by the PHP runtime)
+node_modules/
+**/node_modules

--- a/docker/README.md
+++ b/docker/README.md
@@ -138,7 +138,7 @@ docker-compose exec web php bin/manage-local-users.php add <username> <email> <p
 Pre-built images are available on Docker Hub:
 - Repository: `jeffcaldwellca/scout-portal`
 - Latest: `jeffcaldwellca/scout-portal:latest`
-- Specific versions: `jeffcaldwellca/scout-portal:v1.0.0`
+- Specific versions: `jeffcaldwellca/scout-portal:1.0.0`
 
 Pull the latest image:
 ```bash


### PR DESCRIPTION
`COPY .` was pulling `site/` (~170M, almost all `node_modules`) into the PHP runtime image. The Astro marketing site deploys separately to GitHub Pages, so exclude it (plus stray `node_modules`/`screenshot.png`) from the build context. Left for you to merge.